### PR TITLE
fix: auto-merge release-please PR to complete release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Auto-merge release PR
+        if: steps.release.outputs.prs_created == 'true'
+        run: |
+          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
+          echo "Enabling auto-merge on release PR #${PR_NUMBER}"
+          gh pr merge "${PR_NUMBER}" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ── Sync example csproj versions after release ──
   sync-example-versions:
     name: Sync Example Versions


### PR DESCRIPTION
## Overview

**Type:** fix

**Summary:** Auto-merge release-please PR so that merging a feature PR to main triggers a full release automatically, instead of leaving a Release PR sitting open while all build/publish jobs skip.

**Related Issues:** Fixes release pipeline skipping all jobs on merge to main

---

## Changes Made

### Engine Core (`goud_engine/src/`)
No changes

### FFI Layer (`goud_engine/src/ffi/`)
No changes

### C# SDK (`sdks/csharp/`)
No changes

### Python SDK (`sdks/python/`)
No changes

### TypeScript SDK (`sdks/typescript/`)
No changes

### Codegen Pipeline (`codegen/`)
No changes

### Proc Macros (`goud_engine_macros/`)
No changes

### Tools (`tools/`)
No changes

### WASM (`goud_engine/src/wasm/`)
No changes

### Examples (`examples/`)
No changes

### Documentation
No changes

---

## What was wrong

release-please uses a two-step flow:
1. Merge feature PR to main → release-please creates a Release PR (e.g. PR #89) → `release_created = false` → all build/publish jobs skip
2. Manually merge the Release PR → `release_created = true` → builds and publishes run

Step 2 was missing — nobody merged the Release PR, so the release never happened.

## What this fixes

- Adds an auto-merge step after release-please creates the Release PR
- Uses `gh pr merge --auto --squash` which waits for required CI checks to pass before merging
- Enabled `allow_auto_merge` on the repository settings (already done)

## New flow

1. Merge feature PR to main
2. Release workflow triggers → release-please creates Release PR → auto-merge enabled on it
3. CI runs on Release PR → "CI Success" + "GitGuardian" checks pass
4. GitHub auto-merges the Release PR
5. Push to main triggers Release workflow again → `release_created = true`
6. All build and publish jobs run (npm, NuGet, PyPI, crates.io)

---

## Architectural Compliance

- [x] **Rust-first**: No Rust changes
- [x] **FFI boundary**: No FFI changes
- [x] **Dependency flow**: N/A
- [x] **SDK parity**: N/A
- [x] **Unsafe discipline**: N/A
- [x] **File size**: N/A

---

## Testing

- [x] Pre-commit hooks pass
- [x] CI workflow change only — verified YAML syntax

---

## Breaking Changes

None

---

## Version Bump

**Bump type:** none
**Justification:** CI-only change, no code changes

---

## Security

- [x] No new `unsafe` blocks
- [x] No secrets in committed files
- [x] Uses GITHUB_TOKEN (built-in, not a custom secret)

---

## Reviewer Notes

- Repository setting `allow_auto_merge` was enabled via `gh api` (required for `--auto` flag)
- The auto-merge waits for branch protection checks (CI Success + GitGuardian) before merging
- After this merges, the existing Release PR #89 will be updated and auto-merged on the next push to main
