### PR TITLE
chore: add self-cleaning build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ examples/typescript/**/dist/
 
 # Screenshots from browser testing
 flappy-web-*.png
+
+# Python SDK build output
+sdks/python/dist/
+
+# Claude worktrees (ephemeral, per-session)
+.claude/worktrees/

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # build.sh
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_MODE="debug"
 TARGET_DIR="target/debug"
 
@@ -48,3 +49,18 @@ else
 fi
 
 echo "Build complete."
+
+# Clean old .nupkg files from package output (keep only latest)
+NUPKG_DIR="$SCRIPT_DIR/sdks/nuget_package_output"
+if [ -d "$NUPKG_DIR" ]; then
+    NUPKG_COUNT=$(ls -1 "$NUPKG_DIR"/*.nupkg 2>/dev/null | wc -l)
+    if [ "$NUPKG_COUNT" -gt 1 ]; then
+        LATEST=$(ls -1t "$NUPKG_DIR"/*.nupkg 2>/dev/null | head -1)
+        for pkg in "$NUPKG_DIR"/*.nupkg; do
+            if [ "$pkg" != "$LATEST" ]; then
+                echo "Removing old package: $(basename "$pkg")"
+                rm -f "$pkg"
+            fi
+        done
+    fi
+fi

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# clean.sh — GoudEngine repository cleanup utility
+# Usage: ./clean.sh [--deep | --size | -h]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NUGET_OUTPUT="$SCRIPT_DIR/sdks/nuget_package_output"
+NUGET_LOCAL="$HOME/nuget-local"
+WORKTREES_DIR="$SCRIPT_DIR/.claude/worktrees"
+KEEP_NUGET=3
+
+usage() {
+  echo "Usage: $(basename "$0") [--deep | --size | -h]"
+  echo "  (none)  Lightweight: incremental dirs, bin/obj, __pycache__, .nupkg, screenshots"
+  echo "  --deep  Full: everything above + cargo clean, node_modules, NuGet pruning, worktrees"
+  echo "  --size  Report only — show sizes, no deletions"
+  echo "  -h      Show this help"
+}
+
+kb_to_human() {
+  local kb="$1"
+  if [ "$kb" -ge 1048576 ]; then printf "%.1f GB\n" "$(echo "scale=1; $kb/1048576" | bc)"
+  elif [ "$kb" -ge 1024 ];   then printf "%.1f MB\n" "$(echo "scale=1; $kb/1024" | bc)"
+  else echo "${kb} KB"; fi
+}
+
+path_kb() { [ -e "$1" ] && du -sk "$1" 2>/dev/null | awk '{print $1}' || echo 0; }
+
+find_dirs() { find "$SCRIPT_DIR" "${@}" -type d 2>/dev/null || true; }
+
+# Remove a set of directories found by find args; print reclaimed space.
+remove_dirs() {
+  local label="$1"; shift
+  local total=0
+  while IFS= read -r d; do
+    [ -z "$d" ] && continue
+    local kb; kb=$(path_kb "$d")
+    total=$((total + kb))
+    rm -rf "$d"
+  done < <(find_dirs "$@")
+  echo "  $label: $(kb_to_human $total)"
+}
+
+clean_incremental() {
+  echo "==> Pruning target/debug/incremental older than 7 days..."
+  local before; before=$(path_kb "$SCRIPT_DIR/target/debug/incremental")
+  find "$SCRIPT_DIR/target/debug/incremental" -mindepth 1 -maxdepth 1 \
+    -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+  local after; after=$(path_kb "$SCRIPT_DIR/target/debug/incremental")
+  echo "  Reclaimed: $(kb_to_human $(( before - after )))"
+}
+
+clean_bin_obj() {
+  echo "==> Cleaning bin/ and obj/ (excluding target/)..."
+  remove_dirs "Reclaimed" \
+    -not \( -path "$SCRIPT_DIR/target/*" -prune \) \
+    \( -name "bin" -o -name "obj" \)
+}
+
+clean_pycache() {
+  echo "==> Cleaning __pycache__..."
+  remove_dirs "Reclaimed" -name "__pycache__"
+}
+
+clean_stale_nupkg() {
+  echo "==> Removing stale .nupkg files..."
+  local total=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local kb; kb=$(path_kb "$f")
+    total=$((total + kb))
+    echo "  Removing: $(basename "$f")"; rm -f "$f"
+  done < <(find "$NUGET_OUTPUT" -name "*.nupkg" -type f 2>/dev/null || true)
+  echo "  Reclaimed: $(kb_to_human $total)"
+}
+
+clean_screenshots() {
+  echo "==> Removing flappy-web-*.png screenshots..."
+  local total=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local kb; kb=$(path_kb "$f")
+    total=$((total + kb)); rm -f "$f"
+  done < <(find "$SCRIPT_DIR" -maxdepth 1 -name "flappy-web-*.png" -type f 2>/dev/null || true)
+  echo "  Reclaimed: $(kb_to_human $total)"
+}
+
+clean_cargo() {
+  echo "==> Running cargo clean..."
+  local before; before=$(path_kb "$SCRIPT_DIR/target")
+  (cd "$SCRIPT_DIR" && cargo clean)
+  echo "  Reclaimed: $(kb_to_human $(( before - $(path_kb "$SCRIPT_DIR/target") )))"
+}
+
+clean_node_modules() {
+  echo "==> Removing node_modules/ directories..."
+  remove_dirs "Reclaimed" -name "node_modules" -prune
+}
+
+prune_nuget_local() {
+  echo "==> Pruning ~/nuget-local (keep latest $KEEP_NUGET versions)..."
+  [ -d "$NUGET_LOCAL" ] || { echo "  Not found, skipping."; return; }
+  local total_count
+  total_count=$(find "$NUGET_LOCAL" -name "GoudEngine.*.nupkg" -type f 2>/dev/null | wc -l | tr -d ' ')
+  local remove_count=$((total_count - KEEP_NUGET))
+  if [ "$remove_count" -le 0 ]; then
+    echo "  Nothing to prune ($total_count packages, keeping $KEEP_NUGET)."
+    return
+  fi
+  local reclaimed=0
+  find "$NUGET_LOCAL" -name "GoudEngine.*.nupkg" -type f | sort -V | head -n "$remove_count" | while IFS= read -r pkg; do
+    local kb; kb=$(path_kb "$pkg")
+    reclaimed=$((reclaimed + kb))
+    echo "  Removing: $(basename "$pkg")"; rm -f "$pkg"
+  done
+  echo "  Pruned $remove_count of $total_count packages."
+}
+
+clean_worktrees() {
+  echo "==> Cleaning target/ dirs under .claude/worktrees/..."
+  remove_dirs "Reclaimed" \
+    -path "$WORKTREES_DIR/*" -maxdepth 3 -name "target"
+}
+
+report_sizes() {
+  echo "=== Reclaimable Space Report ==="
+  local grand=0
+  row() {
+    local label="$1" path="$2"
+    local kb; kb=$(path_kb "$path")
+    grand=$((grand + kb))
+    printf "  %-46s %s\n" "$label" "$(kb_to_human $kb)"
+  }
+  row "target/"                             "$SCRIPT_DIR/target"
+  row "target/debug/incremental/"           "$SCRIPT_DIR/target/debug/incremental"
+  row "~/nuget-local/"                      "$NUGET_LOCAL"
+  row ".claude/worktrees/"                  "$WORKTREES_DIR"
+
+  local nm=0
+  while IFS= read -r d; do [ -z "$d" ] && continue; nm=$((nm + $(path_kb "$d"))); done \
+    < <(find "$SCRIPT_DIR" -name "node_modules" -type d -prune 2>/dev/null || true)
+  grand=$((grand + nm))
+  printf "  %-46s %s\n" "node_modules/ (all)" "$(kb_to_human $nm)"
+
+  local bo=0
+  while IFS= read -r d; do [ -z "$d" ] && continue; bo=$((bo + $(path_kb "$d"))); done \
+    < <(find "$SCRIPT_DIR" -not \( -path "$SCRIPT_DIR/target/*" -prune \) \
+          \( -name "bin" -o -name "obj" \) -type d 2>/dev/null || true)
+  grand=$((grand + bo))
+  printf "  %-46s %s\n" "bin/ + obj/ (excl. target/)" "$(kb_to_human $bo)"
+
+  local pc=0
+  while IFS= read -r d; do [ -z "$d" ] && continue; pc=$((pc + $(path_kb "$d"))); done \
+    < <(find "$SCRIPT_DIR" -name "__pycache__" -type d 2>/dev/null || true)
+  grand=$((grand + pc))
+  printf "  %-46s %s\n" "__pycache__/ dirs" "$(kb_to_human $pc)"
+
+  echo ""; printf "  %-46s %s\n" "TOTAL ESTIMATED RECLAIMABLE" "$(kb_to_human $grand)"
+  echo ""; echo "Note: target/ rows overlap — run './clean.sh --deep' to reclaim all."
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --size)    report_sizes; exit 0 ;;
+  --deep)    MODE=deep ;;
+  "")        MODE=default ;;
+  *)         echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+esac
+
+echo "=== GoudEngine cleanup (mode: $MODE) ===" && echo ""
+clean_incremental
+clean_bin_obj
+clean_pycache
+clean_stale_nupkg
+clean_screenshots
+
+if [ "$MODE" = "deep" ]; then
+  clean_cargo
+  clean_node_modules
+  prune_nuget_local
+  clean_worktrees
+fi
+
+echo "" && echo "=== Done. ==="

--- a/dev.sh
+++ b/dev.sh
@@ -113,6 +113,11 @@ esac
 
 # Build the project if not skipped
 if [ "$SKIP_BUILD" = false ]; then
+    # Prune stale incremental compilation cache (>7 days old) to prevent unbounded growth
+    if [ -d "target/debug/incremental" ]; then
+        find "$SCRIPT_DIR/target/debug/incremental" -maxdepth 1 -type d -mtime +7 -exec rm -rf {} + 2>/dev/null
+    fi
+
     # Run cargo check first to catch compilation errors early
     if ! cargo check; then
         echo "Cargo check failed. Fixing errors before proceeding with full build."

--- a/package.sh
+++ b/package.sh
@@ -36,6 +36,21 @@ deploy_local() {
     done
 
     echo "Packages deployed to local NuGet feed at $LOCAL_NUGET_FEED."
+
+    # Prune old NuGet packages — keep latest 3 versions
+    echo "Pruning old NuGet packages..."
+    KEEP_COUNT=3
+    TOTAL_PKGS=$(ls -1 "$LOCAL_NUGET_FEED"/GoudEngine.*.nupkg 2>/dev/null | wc -l | tr -d ' ')
+    REMOVE_COUNT=$((TOTAL_PKGS - KEEP_COUNT))
+    if [ "$REMOVE_COUNT" -gt 0 ]; then
+        ls -1 "$LOCAL_NUGET_FEED"/GoudEngine.*.nupkg | sort -V | head -n "$REMOVE_COUNT" | while read -r pkg; do
+            echo "  Removing: $(basename "$pkg")"
+            rm -f "$pkg"
+        done
+        echo "Pruned to latest $KEEP_COUNT versions."
+    else
+        echo "No old packages to prune."
+    fi
 }
 
 # Function to handle production deployment (TODO)


### PR DESCRIPTION
## Summary

- **`clean.sh`** (new): Central cleanup utility with three modes — default (lightweight prune of incremental cache, bin/obj, __pycache__), `--deep` (full cargo clean + node_modules + NuGet prune), `--size` (report-only)
- **`dev.sh`**: Prunes stale incremental compilation dirs (>7 days) before each build, preventing unbounded `target/` growth
- **`package.sh`**: Auto-prunes `~/nuget-local/` to latest 3 versions after each local deploy
- **`build.sh`**: Removes old `.nupkg` files from `nuget_package_output/` after build
- **`.gitignore`**: Adds missing entries for `sdks/python/dist/` and `.claude/worktrees/`

## Test plan

- [ ] Run `./clean.sh --size` — verify it reports artifact sizes without deleting
- [ ] Run `./clean.sh` — verify lightweight cleanup works (prunes incremental, bin/obj, __pycache__)
- [ ] Run `./clean.sh --deep` — verify full cleanup including cargo clean
- [ ] Run `cargo build` after deep clean — confirm build still works
- [ ] Run `./dev.sh --game flappy_goud` — confirm incremental pruning runs silently before build
- [ ] Run `./package.sh --local` twice — verify old NuGet versions get pruned
- [ ] Run `git status` — confirm no tracked files were deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)