### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the release workflow so it can be manually triggered
- Needed because auto-merge via GITHUB_TOKEN doesn't trigger push events for subsequent workflow runs
- After merging, run `gh workflow run release.yml --ref main` to trigger the 0.0.822 publish

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run release.yml --ref main` to publish 0.0.822

🤖 Generated with [Claude Code](https://claude.com/claude-code)