### PR TITLE
ci: fix agent workflow CI triggers and add failure feedback

### DIFF
--- a/.github/workflows/agent-ci-feedback.yml
+++ b/.github/workflows/agent-ci-feedback.yml
@@ -1,0 +1,105 @@
+name: Agent CI Feedback
+
+on:
+  workflow_run:
+    workflows: ["CI", "PR Validation"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  notify-agent:
+    name: Notify Agent of CI Failure
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
+      - name: Post CI failure feedback to agent PR
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const workflowName = context.payload.workflow_run.name;
+
+            // Get the PR associated with this workflow run
+            const { data: { pull_requests: prs } } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            });
+
+            if (!prs || prs.length === 0) {
+              core.info('No PR associated with this workflow run');
+              return;
+            }
+
+            const prNumber = prs[0].number;
+
+            // Get the PR to check if it's an agent PR
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            if (!pr.head.ref.startsWith('agent/')) {
+              core.info(`PR #${prNumber} is not an agent PR (branch: ${pr.head.ref})`);
+              return;
+            }
+
+            // Count existing CI feedback rounds to prevent infinite loops
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const ciFixRounds = comments.filter(c =>
+              c.body.includes('<!-- agent-ci-fix-round')
+            ).length;
+
+            if (ciFixRounds >= 2) {
+              core.info(`PR #${prNumber} already has ${ciFixRounds} CI fix rounds, leaving for human review`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `<!-- agent-ci-fix-round: ${ciFixRounds + 1} -->\n\nThe **${workflowName}** workflow has failed ${ciFixRounds + 1} times on this agent PR. Remaining CI issues require human review.\n\n[View failed run](${context.payload.workflow_run.html_url})`
+              });
+              return;
+            }
+
+            // Get failed jobs for context
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              filter: 'latest'
+            });
+
+            const failedJobs = jobs
+              .filter(j => j.conclusion === 'failure')
+              .map(j => `- **${j.name}**: [view logs](${j.html_url})`)
+              .join('\n');
+
+            const round = ciFixRounds + 1;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `<!-- agent-ci-fix-round: ${round} -->\n\n@goudengine-agent The **${workflowName}** workflow failed on this PR (round ${round}/2). Please investigate and fix the failures.\n\n### Failed jobs\n${failedJobs || '_No individual job failures found — check the workflow run._'}\n\n[View full run](${context.payload.workflow_run.html_url})`
+            });
+
+            core.info(`Posted CI failure feedback for PR #${prNumber} (round ${round})`);

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -33,9 +33,17 @@ jobs:
             --add-label "agent-working" \
             --repo ${{ github.repository }}
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -46,6 +54,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev libasound2-dev
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli2
 
       - name: Run Claude Code
         id: claude
@@ -68,14 +79,15 @@ jobs:
             - Use conventional commits (feat:, fix:, etc.)
             - Read CLAUDE.md for project conventions
             - Run cargo check, cargo fmt --check, cargo clippy -- -D warnings
+            - If you create or modify .md files, run: npx markdownlint-cli2 '**/*.md' '!**/target/**' '!**/node_modules/**' and fix any errors before committing
             - When opening the PR, read .github/pull_request_template.md and use it to structure the PR body
             - Include "Closes #${{ github.event.issue.number }}" in the Related Issues field
           claude_args: |
             --model claude-opus-4-6
             --max-turns 50
-            --allowedTools "Bash(cargo build:*),Bash(cargo check:*),Bash(cargo test:*),Bash(cargo fmt:*),Bash(cargo clippy:*),Bash(cargo bench:*),Bash(cargo deny:*),Bash(rustup:*),Bash(dotnet:*),Bash(python3:*),Bash(./dev.sh:*),Bash(./build.sh:*),Bash(./increment_version.sh:*),Bash(ls:*),Bash(rg:*),Bash(wc:*),Bash(tree:*),Bash(git:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*),Read,Write,Edit,MultiEdit,Glob,Grep,Agent,Skill,TaskCreate,TaskUpdate,TaskList,TaskGet"
+            --allowedTools "Bash(cargo build:*),Bash(cargo check:*),Bash(cargo test:*),Bash(cargo fmt:*),Bash(cargo clippy:*),Bash(cargo bench:*),Bash(cargo deny:*),Bash(rustup:*),Bash(dotnet:*),Bash(python3:*),Bash(./dev.sh:*),Bash(./build.sh:*),Bash(./increment_version.sh:*),Bash(ls:*),Bash(rg:*),Bash(wc:*),Bash(tree:*),Bash(git:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(npx markdownlint-cli2:*),Read,Write,Edit,MultiEdit,Glob,Grep,Agent,Skill,TaskCreate,TaskUpdate,TaskList,TaskGet"
             --disallowedTools "Bash(cargo publish:*),Bash(gh issue delete:*),Bash(gh repo delete:*)"
-            --append-system-prompt "You are working on GoudEngine, a Rust game engine with C# and Python SDK bindings. Read the root CLAUDE.md for full project context, architecture, and conventions. Key principles: Rust-first (all logic in Rust, SDKs are thin FFI wrappers), layer hierarchy (libs -> engine -> ffi -> sdks -> examples), FFI exports need #[no_mangle] extern C and #[repr(C)], SDK parity (every FFI function must have both C# and Python wrappers). Run cargo check, cargo fmt --check, and cargo clippy after changes."
+            --append-system-prompt "You are working on GoudEngine, a Rust game engine with C# and Python SDK bindings. Read the root CLAUDE.md for full project context, architecture, and conventions. Key principles: Rust-first (all logic in Rust, SDKs are thin FFI wrappers), layer hierarchy (libs -> engine -> ffi -> sdks -> examples), FFI exports need #[no_mangle] extern C and #[repr(C)], SDK parity (every FFI function must have both C# and Python wrappers). Run cargo check, cargo fmt --check, and cargo clippy after changes. If you modify .md files, run npx markdownlint-cli2 on the changed files and fix any errors before pushing."
 
       - name: Check if PR was created
         id: check-pr
@@ -134,9 +146,17 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -148,6 +168,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev libasound2-dev
 
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli2
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
@@ -157,6 +180,6 @@ jobs:
           claude_args: |
             --model claude-opus-4-6
             --max-turns 50
-            --allowedTools "Bash(cargo build:*),Bash(cargo check:*),Bash(cargo test:*),Bash(cargo fmt:*),Bash(cargo clippy:*),Bash(cargo bench:*),Bash(cargo deny:*),Bash(rustup:*),Bash(dotnet:*),Bash(python3:*),Bash(./dev.sh:*),Bash(./build.sh:*),Bash(./increment_version.sh:*),Bash(ls:*),Bash(rg:*),Bash(wc:*),Bash(tree:*),Bash(git:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*),Read,Write,Edit,MultiEdit,Glob,Grep,Agent,Skill,TaskCreate,TaskUpdate,TaskList,TaskGet"
+            --allowedTools "Bash(cargo build:*),Bash(cargo check:*),Bash(cargo test:*),Bash(cargo fmt:*),Bash(cargo clippy:*),Bash(cargo bench:*),Bash(cargo deny:*),Bash(rustup:*),Bash(dotnet:*),Bash(python3:*),Bash(./dev.sh:*),Bash(./build.sh:*),Bash(./increment_version.sh:*),Bash(ls:*),Bash(rg:*),Bash(wc:*),Bash(tree:*),Bash(git:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(npx markdownlint-cli2:*),Read,Write,Edit,MultiEdit,Glob,Grep,Agent,Skill,TaskCreate,TaskUpdate,TaskList,TaskGet"
             --disallowedTools "Bash(cargo publish:*),Bash(gh issue delete:*),Bash(gh repo delete:*)"
-            --append-system-prompt "You are working on GoudEngine, a Rust game engine with C# and Python SDK bindings. Read the root CLAUDE.md for full project context, architecture, and conventions. Key principles: Rust-first (all logic in Rust, SDKs are thin FFI wrappers), layer hierarchy (libs -> engine -> ffi -> sdks -> examples), FFI exports need #[no_mangle] extern C and #[repr(C)], SDK parity (every FFI function must have both C# and Python wrappers). Run cargo check, cargo fmt --check, and cargo clippy after changes."
+            --append-system-prompt "You are working on GoudEngine, a Rust game engine with C# and Python SDK bindings. Read the root CLAUDE.md for full project context, architecture, and conventions. Key principles: Rust-first (all logic in Rust, SDKs are thin FFI wrappers), layer hierarchy (libs -> engine -> ffi -> sdks -> examples), FFI exports need #[no_mangle] extern C and #[repr(C)], SDK parity (every FFI function must have both C# and Python wrappers). Run cargo check, cargo fmt --check, and cargo clippy after changes. If you modify .md files, run npx markdownlint-cli2 on the changed files and fix any errors before pushing."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -156,17 +156,31 @@ jobs:
   lint-markdown:
     name: Lint Markdown Files
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v6
-    
-    - name: Lint Markdown
+
+    - name: Get changed markdown files
+      id: changed
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '\.md$' || true)
+        echo "files<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$FILES" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+        if [ -z "$FILES" ]; then
+          echo "No markdown files changed in this PR"
+        else
+          echo "Changed markdown files:"
+          echo "$FILES"
+        fi
+
+    - name: Lint changed Markdown files
+      if: steps.changed.outputs.files != ''
       uses: DavidAnson/markdownlint-cli2-action@v22
       with:
-        globs: |
-          **/*.md
-          !**/target/**
-          !**/node_modules/**
+        globs: ${{ steps.changed.outputs.files }}
 
   pr-size-labeler:
     name: PR Size Labeler


### PR DESCRIPTION
## Summary

- **App token for agent checkout**: Agent pushes now use a GitHub App token instead of `GITHUB_TOKEN`, so CI and PR Validation workflows actually trigger on agent commits (GitHub ignores `GITHUB_TOKEN` pushes by design)
- **CI failure feedback loop**: New `agent-ci-feedback.yml` workflow posts a comment mentioning `@goudengine-agent` when CI or PR Validation fails on an agent PR, so the interactive agent can fix it (capped at 2 rounds to prevent loops)
- **Markdownlint in agent runner**: Installs `markdownlint-cli2` and adds it to allowed tools + system prompt so the agent lints `.md` files before pushing
- **Scoped markdown lint**: PR Validation now only lints markdown files changed in the PR, preventing pre-existing lint errors from blocking unrelated PRs

## Context

PR #414 exposed three issues: (1) the agent's second push didn't trigger CI because `GITHUB_TOKEN` pushes are ignored, (2) the agent had no feedback loop for CI failures, and (3) the agent didn't know to lint markdown files locally. This PR fixes all three root causes.

## Test plan

- [ ] Verify `agent.yml` YAML is valid (checked locally with `yaml.safe_load`)
- [ ] Verify `agent-ci-feedback.yml` YAML is valid
- [ ] Verify `pr-validation.yml` scoped lint works on this PR (only `.yml` files changed, so lint-markdown should skip)
- [ ] After merge, test with a new agent issue to confirm CI triggers on agent pushes
- [ ] Verify `AGENT_APP_ID` and `AGENT_APP_PRIVATE_KEY` secrets exist (already used by `claude-code-review.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)