### PR TITLE
fix: default empty API responses to 0 in community-stats workflow

### DIFF
--- a/.github/workflows/community-stats.yml
+++ b/.github/workflows/community-stats.yml
@@ -32,6 +32,12 @@ jobs:
           NUGET_DOWNLOADS=$(curl -sf "https://azuresearch-usnc.nuget.org/query?q=packageid:GoudEngine&prerelease=false" | jq '.data[0].totalDownloads // 0')
         fi
 
+        # Ensure all counts default to 0 if API calls fail
+        CRATES_DOWNLOADS=${CRATES_DOWNLOADS:-0}
+        NUGET_DOWNLOADS=${NUGET_DOWNLOADS:-0}
+        PYPI_DOWNLOADS=${PYPI_DOWNLOADS:-0}
+        NPM_DOWNLOADS=${NPM_DOWNLOADS:-0}
+
         # Append to history
         DATE=$(date -u '+%Y-%m-%d')
         python3 -c "


### PR DESCRIPTION
## Summary
- Adds shell parameter expansion defaults (`${VAR:-0}`) for all four registry download count variables (`CRATES_DOWNLOADS`, `NUGET_DOWNLOADS`, `PYPI_DOWNLOADS`, `NPM_DOWNLOADS`)
- Prevents Python `SyntaxError` when a registry API returns an empty response, which produces invalid inline Python like `'crates_io': ,`

## Test plan
- [ ] Review YAML syntax correctness
- [ ] Manually trigger the workflow: `gh workflow run community-stats.yml`
- [ ] Verify the run succeeds: `gh run list --workflow=community-stats.yml --limit=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)