### PR TITLE
ci: trigger CI on main instead of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
## Overview
Type: ci

Switch CI triggers from `develop` to `main` so direct merges to main run CI as expected.

## Changes
- `on.push.branches`: `[develop]` -> `[main]`
- `on.pull_request.branches`: `[main, develop]` -> `[main]`
- Kept `merge_group` trigger unchanged.

## Why
The repository workflow is main-based and does not use a develop branch. This aligns CI triggering with the actual branch strategy.