### PR TITLE
chore: refresh codex agent model mappings

### DIFF
--- a/.agents/agent-catalog.toml
+++ b/.agents/agent-catalog.toml
@@ -29,6 +29,10 @@ role_order = [
 ]
 
 [settings]
+# Codex tier policy:
+# - high tier roles use gpt-5.4
+# - standard tier roles use gpt-5.3-codex
+# - fast tier roles use gpt-5.3-codex-spark
 root_model = "gpt-5.4"
 root_plan_mode_reasoning_effort = "xhigh"
 max_threads = 5

--- a/.agents/role-specs/engine-lead.md
+++ b/.agents/role-specs/engine-lead.md
@@ -9,14 +9,14 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Trivial single-file fix | quick-fix | haiku |
-| Standard implementation | implementer | sonnet |
-| Write failing tests first | test-first-implementer | sonnet |
-| Complex root-cause analysis | debugger | sonnet |
-| Graphics domain questions | graphics-domain-expert | — |
-| ECS domain questions | ecs-domain-expert | — |
+| Task | Agent | Tier |
+|------|-------|------|
+| Trivial single-file fix | quick-fix | fast |
+| Standard implementation | implementer | standard |
+| Write failing tests first | test-first-implementer | standard |
+| Complex root-cause analysis | debugger | standard |
+| Graphics domain questions | graphics-domain-expert | fast |
+| ECS domain questions | ecs-domain-expert | fast |
 
 ## Workflow
 

--- a/.agents/role-specs/integration-lead.md
+++ b/.agents/role-specs/integration-lead.md
@@ -9,13 +9,13 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| FFI export implementation | ffi-implementer | sonnet |
-| C# SDK wrapper | sdk-implementer | sonnet |
-| Python SDK wrapper | sdk-implementer | sonnet |
-| FFI domain questions | ffi-domain-expert | — |
-| Complex debugging | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| FFI export implementation | ffi-implementer | standard |
+| C# SDK wrapper | sdk-implementer | standard |
+| Python SDK wrapper | sdk-implementer | standard |
+| FFI domain questions | ffi-domain-expert | fast |
+| Complex debugging | debugger | standard |
 
 ## Workflow
 

--- a/.agents/role-specs/quality-lead.md
+++ b/.agents/role-specs/quality-lead.md
@@ -9,14 +9,14 @@ You OWN this mission. You are the quality gate. No code reaches the orchestrator
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Spec compliance review | spec-reviewer | sonnet |
-| Code quality review | code-quality-reviewer | sonnet |
-| Architecture validation | architecture-validator | haiku |
-| Security audit (FFI/unsafe) | security-auditor | opus |
-| Test execution | test-runner | sonnet |
-| Test failure diagnosis | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| Spec compliance review | spec-reviewer | standard |
+| Code quality review | code-quality-reviewer | standard |
+| Architecture validation | architecture-validator | fast |
+| Security audit (FFI/unsafe) | security-auditor | high |
+| Test execution | test-runner | standard |
+| Test failure diagnosis | debugger | standard |
 
 ## Review Gate Protocol (MANDATORY)
 

--- a/.agents/rules/orchestrator-protocol.md
+++ b/.agents/rules/orchestrator-protocol.md
@@ -13,22 +13,22 @@ You are the orchestrator. You own ALL code in this repository. Nothing is out of
 ## Three-Tier Agent Hierarchy
 
 ```
-Tier 0: ORCHESTRATOR (root session, opus)
-  |-- engine-lead (opus) -- Rust core, graphics, ECS, assets
-  |   |-- implementer (sonnet)
-  |   |-- test-first-implementer (sonnet)
-  |   |-- debugger (sonnet)
-  |   +-- quick-fix (haiku)
-  |-- integration-lead (opus) -- FFI, C# SDK, Python SDK, TypeScript SDK
-  |   |-- ffi-implementer (sonnet)
-  |   |-- sdk-implementer (sonnet)
-  |   +-- debugger (sonnet)
-  +-- quality-lead (opus) -- reviews, testing, validation
-      |-- spec-reviewer (sonnet)
-      |-- code-quality-reviewer (sonnet)
-      |-- architecture-validator (haiku)
-      |-- security-auditor (opus)
-      +-- test-runner (sonnet)
+Tier 0: ORCHESTRATOR (root session)
+  |-- engine-lead -- Rust core, graphics, ECS, assets
+  |   |-- implementer
+  |   |-- test-first-implementer
+  |   |-- debugger
+  |   +-- quick-fix
+  |-- integration-lead -- FFI, C# SDK, Python SDK, TypeScript SDK
+  |   |-- ffi-implementer
+  |   |-- sdk-implementer
+  |   +-- debugger
+  +-- quality-lead -- reviews, testing, validation
+      |-- spec-reviewer
+      |-- code-quality-reviewer
+      |-- architecture-validator
+      |-- security-auditor
+      +-- test-runner
 ```
 
 ## Delegation Dispatch
@@ -43,15 +43,15 @@ Tier 0: ORCHESTRATOR (root session, opus)
 
 ## Model Tier Strategy
 
-Select the right model for the right task:
+Select the right tier for the task. Provider-specific model assignments live in `.agents/agent-catalog.toml` and the generated wrappers.
 
-| Tier | Model | Use For |
-|------|-------|---------|
-| Quick | haiku | Single-file fixes, lightweight validation, read-heavy scans |
-| Standard | sonnet | Implementation, reviews, testing, and debugging |
-| Complex | opus | Security audits and sub-orchestration |
+| Tier | Use For |
+|------|---------|
+| Fast | Single-file fixes, lightweight validation, read-heavy scans |
+| Standard | Implementation, reviews, testing, and debugging |
+| High | Sub-orchestration, security audits, and highest-judgment work |
 
-Team leads (engine-lead, integration-lead, quality-lead) always run on opus because they manage other agents.
+Team leads (engine-lead, integration-lead, quality-lead) stay in the high tier because they manage other agents.
 
 ## Mandatory Skills
 

--- a/.agents/skills/subagent-driven-development/SKILL.md
+++ b/.agents/skills/subagent-driven-development/SKILL.md
@@ -32,7 +32,7 @@ Classify the work:
 - **Engine-only**: Dispatch engine-lead
 - **FFI + SDK**: Dispatch integration-lead (or engine-lead + integration-lead if Rust core also changes)
 - **Cross-cutting**: Dispatch engine-lead AND integration-lead in parallel, then quality-lead for review
-- **Trivial fix**: Dispatch quick-fix (haiku) directly
+- **Trivial fix**: Dispatch quick-fix directly
 
 ### 2. Dispatch Team Leads
 
@@ -97,11 +97,13 @@ python3 sdks/python/test_bindings.py    # Python SDK tests
 
 ## Model Tier Selection
 
-| Tier | Model | Agents |
-|------|-------|--------|
-| Quick | haiku | quick-fix |
-| Standard | sonnet | implementer, ffi-implementer, sdk-implementer, test-first-implementer, spec-reviewer, code-quality-reviewer, architecture-validator, test-runner |
-| Complex | opus | engine-lead, integration-lead, quality-lead, security-auditor, debugger |
+Provider-specific model assignments live in `.agents/agent-catalog.toml` and the generated wrappers.
+
+| Tier | Agents | Use For |
+|------|--------|---------|
+| Fast | quick-fix, architecture-validator, explorer, monitor, domain experts | Single-file fixes, read-heavy scans, lightweight validation |
+| Standard | implementer, ffi-implementer, sdk-implementer, test-first-implementer, spec-reviewer, code-quality-reviewer, test-runner, debugger, worker, documentation-writer | Implementation, reviews, testing, and debugging |
+| High | engine-lead, integration-lead, quality-lead, security-auditor, default | Sub-orchestration, security review, and highest-judgment work |
 
 ## Governance (Hook-Enforced)
 

--- a/.claude/agents/engine-lead.md
+++ b/.claude/agents/engine-lead.md
@@ -25,14 +25,14 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Trivial single-file fix | quick-fix | haiku |
-| Standard implementation | implementer | sonnet |
-| Write failing tests first | test-first-implementer | sonnet |
-| Complex root-cause analysis | debugger | sonnet |
-| Graphics domain questions | graphics-domain-expert | — |
-| ECS domain questions | ecs-domain-expert | — |
+| Task | Agent | Tier |
+|------|-------|------|
+| Trivial single-file fix | quick-fix | fast |
+| Standard implementation | implementer | standard |
+| Write failing tests first | test-first-implementer | standard |
+| Complex root-cause analysis | debugger | standard |
+| Graphics domain questions | graphics-domain-expert | fast |
+| ECS domain questions | ecs-domain-expert | fast |
 
 ## Workflow
 

--- a/.claude/agents/integration-lead.md
+++ b/.claude/agents/integration-lead.md
@@ -25,13 +25,13 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| FFI export implementation | ffi-implementer | sonnet |
-| C# SDK wrapper | sdk-implementer | sonnet |
-| Python SDK wrapper | sdk-implementer | sonnet |
-| FFI domain questions | ffi-domain-expert | — |
-| Complex debugging | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| FFI export implementation | ffi-implementer | standard |
+| C# SDK wrapper | sdk-implementer | standard |
+| Python SDK wrapper | sdk-implementer | standard |
+| FFI domain questions | ffi-domain-expert | fast |
+| Complex debugging | debugger | standard |
 
 ## Workflow
 

--- a/.claude/agents/quality-lead.md
+++ b/.claude/agents/quality-lead.md
@@ -25,14 +25,14 @@ You OWN this mission. You are the quality gate. No code reaches the orchestrator
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Spec compliance review | spec-reviewer | sonnet |
-| Code quality review | code-quality-reviewer | sonnet |
-| Architecture validation | architecture-validator | haiku |
-| Security audit (FFI/unsafe) | security-auditor | opus |
-| Test execution | test-runner | sonnet |
-| Test failure diagnosis | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| Spec compliance review | spec-reviewer | standard |
+| Code quality review | code-quality-reviewer | standard |
+| Architecture validation | architecture-validator | fast |
+| Security audit (FFI/unsafe) | security-auditor | high |
+| Test execution | test-runner | standard |
+| Test failure diagnosis | debugger | standard |
 
 ## Review Gate Protocol (MANDATORY)
 

--- a/.codex/agents/engine-lead.toml
+++ b/.codex/agents/engine-lead.toml
@@ -15,14 +15,14 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Trivial single-file fix | quick-fix | haiku |
-| Standard implementation | implementer | sonnet |
-| Write failing tests first | test-first-implementer | sonnet |
-| Complex root-cause analysis | debugger | sonnet |
-| Graphics domain questions | graphics-domain-expert | — |
-| ECS domain questions | ecs-domain-expert | — |
+| Task | Agent | Tier |
+|------|-------|------|
+| Trivial single-file fix | quick-fix | fast |
+| Standard implementation | implementer | standard |
+| Write failing tests first | test-first-implementer | standard |
+| Complex root-cause analysis | debugger | standard |
+| Graphics domain questions | graphics-domain-expert | fast |
+| ECS domain questions | ecs-domain-expert | fast |
 
 ## Workflow
 

--- a/.codex/agents/integration-lead.toml
+++ b/.codex/agents/integration-lead.toml
@@ -15,13 +15,13 @@ You OWN this mission. The orchestrator gives you objectives, not step-by-step in
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| FFI export implementation | ffi-implementer | sonnet |
-| C# SDK wrapper | sdk-implementer | sonnet |
-| Python SDK wrapper | sdk-implementer | sonnet |
-| FFI domain questions | ffi-domain-expert | — |
-| Complex debugging | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| FFI export implementation | ffi-implementer | standard |
+| C# SDK wrapper | sdk-implementer | standard |
+| Python SDK wrapper | sdk-implementer | standard |
+| FFI domain questions | ffi-domain-expert | fast |
+| Complex debugging | debugger | standard |
 
 ## Workflow
 

--- a/.codex/agents/quality-lead.toml
+++ b/.codex/agents/quality-lead.toml
@@ -15,14 +15,14 @@ You OWN this mission. You are the quality gate. No code reaches the orchestrator
 
 ## Dispatch Table
 
-| Task | Agent | Model |
-|------|-------|-------|
-| Spec compliance review | spec-reviewer | sonnet |
-| Code quality review | code-quality-reviewer | sonnet |
-| Architecture validation | architecture-validator | haiku |
-| Security audit (FFI/unsafe) | security-auditor | opus |
-| Test execution | test-runner | sonnet |
-| Test failure diagnosis | debugger | sonnet |
+| Task | Agent | Tier |
+|------|-------|------|
+| Spec compliance review | spec-reviewer | standard |
+| Code quality review | code-quality-reviewer | standard |
+| Architecture validation | architecture-validator | fast |
+| Security audit (FFI/unsafe) | security-auditor | high |
+| Test execution | test-runner | standard |
+| Test failure diagnosis | debugger | standard |
 
 ## Review Gate Protocol (MANDATORY)
 


### PR DESCRIPTION
## Overview

**Type:** chore

**Summary:**
Refresh the Codex agent source docs and generated wrappers so Codex roles use the current GPT-5.4 / GPT-5.3-Codex / GPT-5.3-Codex-Spark family in config while shared role instructions stay provider-neutral. Claude agent model assignments remain unchanged.

**Related Issues:** None

---

## Changes Made

### Engine Core (`goud_engine/src/`)
No changes

### FFI Layer (`goud_engine/src/ffi/`)
No changes

### C# SDK (`sdks/csharp/`)
No changes

### Python SDK (`sdks/python/`)
No changes

### TypeScript SDK (`sdks/typescript/`)
No changes

### Codegen Pipeline (`codegen/`)
No changes

### Proc Macros (`goud_engine_macros/`)
No changes

### Tools (`tools/`)
No changes

### WASM (`goud_engine/src/wasm/`)
No changes

### Examples (`examples/`)
No changes

### Documentation
- Replaced Claude-specific model names in shared role specs with provider-neutral tier labels
- Updated orchestration docs to point model selection back to `.agents/agent-catalog.toml`
- Added a short Codex tier policy comment to the agent catalog
- Regenerated the affected Codex and Claude agent wrappers

---

## Architectural Compliance

- [x] **Rust-first**: All logic lives in Rust; SDKs are thin wrappers
- [x] **FFI boundary**: New exports use `#[no_mangle] extern "C"` and `#[repr(C)]` where needed
- [x] **Dependency flow**: Imports follow layer hierarchy (down only)
- [x] **SDK parity**: Changes exposed via FFI are wrapped in C#, Python, AND TypeScript SDKs
- [x] **Unsafe discipline**: No `unsafe` block without a `// SAFETY:` comment
- [x] **File size**: No file exceeds 500 lines

---

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` is clean
- [ ] `cargo fmt --all -- --check` passes
- [ ] Python SDK tests pass (`python3 sdks/python/test_bindings.py`) — if SDK changed
- [ ] C# SDK tests pass (`dotnet test sdks/csharp.tests/`) — if SDK changed
- [ ] TypeScript SDK tests pass (`cd sdks/typescript && npm test`) — if TS SDK changed
- [ ] Codegen produces consistent output (`python3 codegen/validate.py && python3 codegen/validate_coverage.py`)
- [ ] Pre-commit hooks pass
- [x] `python3 scripts/sync-agent-configs.py`
- [x] `python3 scripts/sync-agent-configs.py --check`
- [x] Verified no stale `haiku` / `sonnet` / `opus` labels remain in `.codex/agents/`
- [x] Verified Claude frontmatter still uses `haiku`, `sonnet`, and `opus`

---

## Code Quality

- [x] No `todo!()` or `unimplemented!()` in production code
- [x] No `#[allow(unused)]` without justification comment
- [x] Error handling uses `Result`, not `unwrap()`/`expect()` in library code
- [x] Public items have doc comments

---

## Documentation

- [x] Updated relevant `AGENTS.md` files (if architecture changed)
- [ ] Updated `README.md` (if user-facing behavior changed)
- [ ] Added or updated doc comments on new public APIs

---

## Breaking Changes

None

- API changes: None
- FFI signature changes: None
- SDK interface changes: None

---

## Version Bump

**Bump type:** none
**Justification:** This change only updates agent configuration metadata, shared workflow docs, and regenerated wrappers.

---

## Security

- [x] No new `unsafe` blocks — or each one has a `// SAFETY:` comment and is necessary
- [x] No new FFI pointer parameters without null checks
- [x] No new dependencies with known advisories (`cargo deny check`)
- [x] No secrets or credentials in committed files

---

## Performance

N/A

---

## Deployment

- [ ] NuGet package version updated (if SDK changed)
- [ ] Python package version updated (if SDK changed)
- [ ] npm package version updated (if TS SDK changed)
- [ ] Native library builds on all targets (macOS, Linux, Windows)

---

## Reviewer Notes

- The catalog already matched the intended Codex model family before this change; the main fix is removing stale Claude-specific model labels from shared specs so regenerated Codex wrappers read correctly.
- Review the shared docs and generated wrappers together: the source-of-truth is `.agents/agent-catalog.toml` plus `.agents/role-specs/*.md`, and `.codex/` / `.claude/agents/` remain generated outputs.
