### PR TITLE
fix: remove version from ffi_manifest to prevent release drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,14 +1668,14 @@ dependencies = [
 
 [[package]]
 name = "goud-engine"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "goud-engine-core",
 ]
 
 [[package]]
 name = "goud-engine-core"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "bincode",
  "bindgen",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "goud-engine-node"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "goud-engine-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "goud_engine_macros"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/codegen/ffi_manifest.json
+++ b/codegen/ffi_manifest.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.0.828",
   "generated_at": "build-time",
   "functions": {
     "goud_animation_clip_add_event": {

--- a/goud_engine/build.rs
+++ b/goud_engine/build.rs
@@ -196,7 +196,6 @@ struct FfiFunction {
 ///
 /// Returns the total number of functions extracted.
 fn generate_ffi_manifest(manifest_dir: &str, output_path: &Path) -> usize {
-    let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
     let generated_at = "build-time".to_string();
 
     let mut functions: BTreeMap<String, FfiFunction> = BTreeMap::new();
@@ -217,7 +216,7 @@ fn generate_ffi_manifest(manifest_dir: &str, output_path: &Path) -> usize {
     let total_count = functions.len();
 
     // Build JSON manually to avoid adding serde as a build-dependency
-    let json = build_manifest_json(&version, &generated_at, &functions, total_count);
+    let json = build_manifest_json(&generated_at, &functions, total_count);
 
     // Ensure output directory exists
     if let Some(parent) = output_path.parent() {
@@ -408,14 +407,12 @@ fn parse_params(params_str: &str) -> Vec<String> {
 
 /// Builds the manifest JSON string manually (no serde dependency).
 fn build_manifest_json(
-    version: &str,
     generated_at: &str,
     functions: &BTreeMap<String, FfiFunction>,
     total_count: usize,
 ) -> String {
     let mut json = String::with_capacity(64 * 1024);
     json.push_str("{\n");
-    json.push_str(&format!("  \"version\": \"{version}\",\n"));
     json.push_str(&format!("  \"generated_at\": \"{generated_at}\",\n"));
     json.push_str("  \"functions\": {\n");
 

--- a/tools/goudengine-mcp/src/server/tests/support.rs
+++ b/tools/goudengine-mcp/src/server/tests/support.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::io::{self, ErrorKind, Read, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc::sync_channel;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use goud_engine::core::debugger::{


### PR DESCRIPTION
## Summary
- Removes `version` field from `ffi_manifest.json` output in `build.rs` to eliminate release-please drift
- Root cause: release-please bumps `Cargo.toml` but doesn't run `cargo build`, so `ffi_manifest.json` retains the old `CARGO_PKG_VERSION` and the CI drift check fails on main
- Nothing reads the version from this manifest (confirmed: codegen only reads `functions`), so removal is safe
- Also fixes import ordering in MCP test support file and includes Cargo.lock update for 0.0.829

## Test plan
- [x] `cargo build` — regenerates manifest without version field
- [x] `cargo test` — 583 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `./codegen.sh` — all SDKs regenerated successfully
- [x] `python3 codegen/validate.py` — schema in sync
- [x] `python3 codegen/validate_coverage.py` — 100% coverage (447/447)
- [ ] CI: Release workflow passes on main after merge
- [ ] CI: Deploy Docs workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)