### PR TITLE
fix: resolve Windows CI test flakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,14 +1668,14 @@ dependencies = [
 
 [[package]]
 name = "goud-engine"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "goud-engine-core",
 ]
 
 [[package]]
 name = "goud-engine-core"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "bincode",
  "bindgen",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "goud-engine-node"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "goud-engine-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "goud_engine_macros"
-version = "0.0.828"
+version = "0.0.829"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/goud_engine/src/assets/loaders/texture/asset.rs
+++ b/goud_engine/src/assets/loaders/texture/asset.rs
@@ -70,15 +70,16 @@ impl TextureAsset {
     /// assert_eq!(texture.pixel_count(), 16);
     /// ```
     pub fn new(data: Vec<u8>, width: u32, height: u32, format: TextureFormat) -> Self {
-        assert_eq!(
-            data.len(),
-            (width * height * 4) as usize,
-            "Texture data length mismatch: expected {} bytes for {}x{} RGBA8, got {}",
-            width * height * 4,
-            width,
-            height,
-            data.len()
-        );
+        let expected_len = (width * height * 4) as usize;
+        if data.len() != expected_len {
+            panic!(
+                "Texture data length mismatch: expected {} bytes for {}x{} RGBA8, got {}",
+                expected_len,
+                width,
+                height,
+                data.len()
+            );
+        }
         Self {
             data,
             width,

--- a/goud_engine/src/core/debugger/mod.rs
+++ b/goud_engine/src/core/debugger/mod.rs
@@ -185,6 +185,8 @@ pub(crate) use runtime::attach_session_heartbeat_for_tests;
 pub(crate) use runtime::manifest_artifact_path_for_tests;
 #[cfg(test)]
 pub(crate) use runtime::reset_for_tests;
+#[cfg(test)]
+pub(crate) use runtime::stop_attach_server_for_tests;
 
 #[cfg(test)]
 pub(crate) fn test_lock() -> MutexGuard<'static, ()> {

--- a/goud_engine/src/core/debugger/runtime.rs
+++ b/goud_engine/src/core/debugger/runtime.rs
@@ -346,6 +346,14 @@ pub(crate) use attach::{
 };
 
 #[cfg(test)]
+pub(crate) fn stop_attach_server_for_tests() {
+    let mut guard = lock_runtime();
+    if let Some(runtime) = guard.as_mut() {
+        attach::stop_local_attach_server(runtime);
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn reset_for_tests() {
     let mut guard = lock_runtime();
     if let Some(runtime) = guard.as_mut() {

--- a/goud_engine/src/core/debugger/tests/attach.rs
+++ b/goud_engine/src/core/debugger/tests/attach.rs
@@ -1,7 +1,8 @@
 use super::super::{
     attach_hello_for_tests, attach_request_json_for_tests, attach_session_heartbeat_for_tests,
-    current_manifest, register_context, reset_for_tests, snapshot_for_route, test_lock,
-    AttachAcceptedV1, AttachHelloV1, DebuggerConfig, RuntimeSurfaceKind,
+    current_manifest, register_context, reset_for_tests, snapshot_for_route,
+    stop_attach_server_for_tests, test_lock, AttachAcceptedV1, AttachHelloV1, DebuggerConfig,
+    RuntimeSurfaceKind,
 };
 use crate::core::context_id::GoudContextId;
 use interprocess::local_socket::{prelude::*, GenericFilePath, Stream};
@@ -105,6 +106,9 @@ fn test_attach_session_heartbeat_is_out_of_band() {
             route_label: Some("heartbeat".to_string()),
         },
     );
+    // Stop the IPC server to prevent background thread interference with session state.
+    // This test exercises the direct function-call heartbeat path, not the IPC path.
+    stop_attach_server_for_tests();
 
     let accepted = attach_hello_for_tests(AttachHelloV1 {
         protocol_version: 1,


### PR DESCRIPTION
## Summary

- Replace `assert_eq!` with explicit `if` + `panic!()` in `TextureAsset::new()` so the panic message is platform-consistent and `#[should_panic(expected = "Texture data length mismatch")]` reliably matches on Windows
- Stop the IPC attach server after `register_context` in `test_attach_session_heartbeat_is_out_of_band` to prevent background thread interference with session state (the test exercises the direct function-call heartbeat path, not IPC)
- Include Cargo.lock version sync from v0.0.829 release

## Test plan

- [x] `cargo test test_new_wrong_size` passes
- [x] `cargo test test_attach_session_heartbeat_is_out_of_band` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Windows CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)