### PR TITLE
fix(ci): bump rustls-webpki to 0.103.13 to clear RUSTSEC-2026-0098/0099/0104

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,5 @@
 [advisories]
-ignore = [
-    # rustls-webpki CRL matching issue; limited impact, requires compromised CA; transitive dep via tungstenite
-    "RUSTSEC-2026-0049",
-]
+# rustls-webpki advisories (RUSTSEC-2026-0049/0098/0099/0104) were resolved by upgrading
+# rustls-webpki to >=0.103.13. Keep this file present so future ignores can be added without
+# editing the workflow.
+ignore = []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,14 +1827,14 @@ dependencies = [
 
 [[package]]
 name = "goud-engine"
-version = "0.0.839"
+version = "0.0.841"
 dependencies = [
  "goud-engine-core",
 ]
 
 [[package]]
 name = "goud-engine-core"
-version = "0.0.839"
+version = "0.0.841"
 dependencies = [
  "bincode",
  "bindgen",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "goud-engine-node"
-version = "0.0.839"
+version = "0.0.841"
 dependencies = [
  "goud-engine-core",
  "napi",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "goud_engine_macros"
-version = "0.0.839"
+version = "0.0.841"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -72,10 +72,8 @@ feature-depth = 1
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "paste is a transitive dep of wgpu→metal; no alternative available upstream" },
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 is considered complete by its authors; used for scene serialization" },
-    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki CRL matching issue; limited impact, requires compromised CA; transitive dep of rustls via tungstenite" },
     { id = "RUSTSEC-2026-0097", reason = "rand unsoundness only triggers when a custom global logger calls rand::rng(); engine does not set one" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI-name constraint issue; transitive via tungstenite; mitigated upstream path" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name-constraint issue; same transitive path as 2026-0098" },
+    { id = "RUSTSEC-2026-0105", reason = "core2 unmaintained; transitive via image→ravif→rav1e→bitstream-io. No replacement version published." },
     { crate = "core2@0.4.0", reason = "yanked upstream; transitive via image→ravif→rav1e→bitstream-io. No replacement version published." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.


### PR DESCRIPTION
## Overview

**Type:** ci

**Summary:**
The nightly `Rust Security Audit` job (`.github/workflows/security.yml`) has been failing because `rustls-webpki 0.103.9` is affected by three vulnerabilities published in April 2026. A precise lockfile bump to `rustls-webpki 0.103.13` resolves all three without any manifest changes.

**Related Issues:** Refs #599

---

## Changes Made

### Engine Core (`goud_engine/src/`)
No changes.

### FFI Layer (`goud_engine/src/ffi/`)
No changes.

### C# / Python / TypeScript SDKs
No changes.

### Tools / Examples / Docs
No changes.

### Build / Dependency Configuration
- `Cargo.lock` — `rustls-webpki 0.103.9 → 0.103.13` (precise update, no other transitive bumps).
- `.cargo/audit.toml` — drop the now-stale `RUSTSEC-2026-0049` ignore. The file is retained (empty `ignore = []`) so future ignores can be added without editing the workflow.
- `deny.toml` — drop `RUSTSEC-2026-0049`, `RUSTSEC-2026-0098`, `RUSTSEC-2026-0099` ignores (all cleared by the upgrade); add `RUSTSEC-2026-0105` (core2 unmaintained, 2026-04-14). The existing `core2@0.4.0` crate-level entry only covers the yanked status, not the new unmaintained advisory ID, and `cargo-deny` treats unmaintained as an error by default.

---

## Advisories Resolved

| ID | Crate | Date | Resolution |
|---|---|---|---|
| [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) | rustls-webpki | 2026-04-22 | Upgrade to >=0.103.13 |
| [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) | rustls-webpki | 2026-04-14 | Upgrade to >=0.103.12 |
| [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) | rustls-webpki | 2026-04-14 | Upgrade to >=0.103.12 |
| [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049) | rustls-webpki | (prior ignore) | Cleared by same upgrade; ignore removed |
| [RUSTSEC-2026-0105](https://rustsec.org/advisories/RUSTSEC-2026-0105) | core2 | 2026-04-14 | Ignored — no maintained replacement; transitive via `image → ravif → rav1e → bitstream-io` |

---

## Architectural Compliance

- [x] **Rust-first**: All logic lives in Rust; SDKs are thin wrappers — no SDK or engine code touched.
- [x] **FFI boundary**: No FFI changes.
- [x] **Dependency flow**: No source changes.
- [x] **SDK parity**: N/A — no FFI exports added.
- [x] **Unsafe discipline**: No new `unsafe` blocks.
- [x] **File size**: No file exceeds 500 lines (only config edits).

---

## Testing

- [x] `cargo audit` — exit 0 (6 allowed warnings).
- [x] `cargo deny --all-features check` — `advisories ok, bans ok, licenses ok, sources ok`.
- [x] `cargo check --workspace` — exit 0.
- [ ] `cargo test` — not re-run; no source changes.
- [ ] `cargo clippy -- -D warnings` — not re-run; no source changes.
- [ ] `cargo fmt --all -- --check` — not re-run; no source changes.

---

## Code Quality / Documentation

No code or documentation changes — config-only.

---

## Breaking Changes

None. `rustls-webpki` 0.103.x is a stable patch line; the upgrade from 0.103.9 to 0.103.13 is API-compatible.

---

## Version Bump

**Bump type:** none
**Justification:** Lockfile + advisory configuration only; no public API surface affected.

---

## Security

- [x] No new `unsafe` blocks.
- [x] No new FFI pointer parameters.
- [x] `cargo deny check` is clean post-change.
- [x] No secrets or credentials in committed files.

---

## Performance

N/A — config only.

---

## Deployment

No package changes.

---

## Reviewer Notes

- Issue #599 is the auto-filed nightly tracker for this same failure; it should auto-close (or stop being reopened) once `security.yml` runs green on `main`.
- The lockfile diff also normalizes the workspace member version from `0.0.839 → 0.0.841` to match `Cargo.toml` (release-please had bumped manifests to 0.0.841 already; the lockfile was stale). This is a no-op cargo update side effect, not an intentional version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)